### PR TITLE
exclude more resampled files, including converted and focuspoint ones

### DIFF
--- a/app/variables.go
+++ b/app/variables.go
@@ -31,8 +31,8 @@ var (
 	// ResampledRegex regular expressions should match all common thumbnail manipulations except for
 	// resized images as those tend to be linked from HTMLText and aren't auto-generated without a republish
 	ResampledRegex = []*regexp.Regexp{
-		// Silverstripe 4
-		regexp.MustCompile(`(?i)\_\_(Fit|Fill|Scale|Resampled)([a-z0-9]+)\.(jpg|png|jpeg|tiff)$`),
+		// Silverstripe 4 and 5
+		regexp.MustCompile(`(?i)\_\_(Crop|ExtRewrite|Fill|Fit|Focus|Pad|Quality|Resampled|Scale)([a-z0-9_]*)\.[a-z0-9]{1,4}$`),
 
 		// Silverstripe 3
 		regexp.MustCompile(`(?i)\/\_resampled\/(Pad|CMSThumbnail|stripthumbnail|Cropped|Set|Fit|Fill|Scale|Resampled).*\.(jpg|png|jpeg|tiff)`),


### PR DESCRIPTION
This expands the regex to exclude more resampled files, including converted ones (SS 5.3) as well as ones generated by https://github.com/jonom/silverstripe-focuspoint. 

It also allows for any file extensions with a length between 1 and 4 (this includes webp and avif images, but also other converted files like pdf). 